### PR TITLE
Change from rl_eof_found to line is NULL

### DIFF
--- a/code/lsh.c
+++ b/code/lsh.c
@@ -40,8 +40,7 @@ int main(void)
     char *line;
     line = readline("> ");
 
-    if (rl_eof_found) {
-      free(line);
+    if (line == NULL) {
       break;
     }
 


### PR DESCRIPTION
`rl_eof_found` dependency is not part of GNU readline library.

Using `line == NULL` works, without segmentation fault.